### PR TITLE
Allow customization of the placeholder character

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,13 +37,13 @@ function mergeFormatCharacters(formatCharacters) {
   return merged
 }
 
-var PLACEHOLDER = '_'
 var ESCAPE_CHAR = '\\'
 
 var DIGIT_RE = /^\d$/
 var LETTER_RE = /^[A-Za-z]$/
 var ALPHANNUMERIC_RE = /^[\dA-Za-z]$/
 
+var DEFAULT_PLACEHOLDER_CHAR = '_'
 var DEFAULT_FORMAT_CHARACTERS = {
   '*': {
     validate: function(char) { return ALPHANNUMERIC_RE.test(char) }
@@ -68,9 +68,13 @@ var DEFAULT_FORMAT_CHARACTERS = {
  * @param {string} source
  * @patam {?Object} formatCharacters
  */
-function Pattern(source, formatCharacters) {
-  if (!(this instanceof Pattern)) { return new Pattern(source) }
+function Pattern(source, formatCharacters, placeholderChar) {
+  if (!(this instanceof Pattern)) {
+    return new Pattern(source, formatCharacters, placeholderChar)
+  }
 
+  /** Placeholder character */
+  this.placeholderChar = placeholderChar || DEFAULT_PLACEHOLDER_CHAR
   /** Format character definitions. */
   this.formatCharacters = formatCharacters || DEFAULT_FORMAT_CHARACTERS
   /** Pattern definition string with escape characters. */
@@ -137,7 +141,7 @@ Pattern.prototype.formatValue = function format(value) {
     if (this.isEditableIndex(i)) {
       valueBuffer[i] = (value.length > valueIndex && this.isValidAtIndex(value[valueIndex], i)
                         ? this.transform(value[valueIndex], i)
-                        : PLACEHOLDER)
+                        : this.placeholderChar)
       valueIndex++
     }
     else {
@@ -181,6 +185,7 @@ function InputMask(options) {
   options = extend({
     formatCharacters: null,
     pattern: null,
+    placeholderChar: DEFAULT_PLACEHOLDER_CHAR,
     selection: {start: 0, end: 0},
     value: ''
   }, options)
@@ -189,6 +194,11 @@ function InputMask(options) {
     throw new Error('InputMask: you must provide a pattern.')
   }
 
+  if (options.placeholderChar.length !== 1) {
+    throw new Error('InputMask: placeholderChar should be a single character.');
+  }
+
+  this.placeholderChar = options.placeholderChar
   this.formatCharacters = mergeFormatCharacters(options.formatCharacters)
   this.setPattern(options.pattern, {
     value: options.value,
@@ -237,7 +247,7 @@ InputMask.prototype.input = function input(char) {
   var end = this.selection.end - 1
   while (end > inputIndex) {
     if (this.pattern.isEditableIndex(end)) {
-      this.value[end] = PLACEHOLDER
+      this.value[end] = this.placeholderChar
     }
     end--
   }
@@ -290,7 +300,7 @@ InputMask.prototype.backspace = function backspace() {
   // No range selected - work on the character preceding the cursor
   if (this.selection.start === this.selection.end) {
     if (this.pattern.isEditableIndex(this.selection.start - 1)) {
-      this.value[this.selection.start - 1] = PLACEHOLDER
+      this.value[this.selection.start - 1] = this.placeholderChar
     }
     this.selection.start--
     this.selection.end--
@@ -300,7 +310,7 @@ InputMask.prototype.backspace = function backspace() {
     var end = this.selection.end - 1
     while (end >= this.selection.start) {
       if (this.pattern.isEditableIndex(end)) {
-        this.value[end] = PLACEHOLDER
+        this.value[end] = this.placeholderChar
       }
       end--
     }
@@ -441,7 +451,7 @@ InputMask.prototype.setPattern = function setPattern(pattern, options) {
     selection: {start: 0, end: 0},
     value: ''
   }, options)
-  this.pattern = new Pattern(pattern, this.formatCharacters)
+  this.pattern = new Pattern(pattern, this.formatCharacters, this.placeholderChar);
   this.setValue(options.value)
   this.emptyValue = this.pattern.formatValue([]).join('')
   this.selection = options.selection

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,7 @@ test('formatValueToPattern', function(t) {
 })
 
 test('Constructor options', function(t) {
-  t.plan(12)
+  t.plan(16)
 
   t.throws(function() { new InputMask },
            /InputMask: you must provide a pattern./,
@@ -69,6 +69,16 @@ test('Constructor options', function(t) {
   mask.setPattern('--11--', {value: '99'})
   t.equal(mask.getValue(), '--99--', 'New pattern value is set')
   t.equal(mask.emptyValue, '--__--', 'emptyValue is updated after setPattern')
+
+  // Custom placeholder char can be provided.
+  mask = new InputMask({pattern: '--11--', value: '98', placeholderChar: ' '})
+  t.equal(mask.getValue(), '--98--', 'Initial value is formatted as expected')
+  t.equal(mask.emptyValue, '--  --', 'emptyValue checks out with custom placeholderChar')
+
+  mask = new InputMask({pattern: '--11--', value: '98', placeholderChar: '#'})
+  t.equal(mask.emptyValue, '--##--', 'emptyValue with updated placeholderChar')
+  t.equal(mask.getValue(), '--98--',
+          'Initial value is formatted with another different placeholderChar')
 
   // Custom format characters can be configured per-mask
   mask = new InputMask({
@@ -167,13 +177,30 @@ test('Input with selected range', function(t) {
   t.true(mask.input('2'), 'Valid input accepted')
   t.equal(mask.getValue(), '1234 12__ __34 1234', 'Only blanks out input positions')
 
-  // If a range of charactes are selected and the first character was contained
+  // If a range of characters are selected and the first character was contained
   // in the range, any input given should apply to it.
   mask = new InputMask({pattern: '----- 1111 1111'})
   mask.selection = {start: 0, end: 15}
   t.true(mask.input('2'), 'Valid input accepted')
   t.equal(mask.getValue(), '----- 2___ ____', 'Value was applied to the first editable character')
   t.deepEqual(mask.selection, {start: 7, end: 7}, 'Cursor was placed after first editable character')
+})
+
+test('Providing a custom placeholder character', function(t) {
+  t.plan(4)
+
+  var mask = new InputMask({pattern: '---- 1111', placeholderChar: ' '})
+  mask.selection = {start: 0, end: 15}
+  t.true(mask.input('3'), 'Valid input accepted with custom placeholderChar')
+  t.equal(mask.getValue(), '---- 3   ',
+          'Value applied to the first editable char with custom placeholderChar')
+  t.throws(function() { new InputMask({pattern: '--11', placeholderChar: '__'}) },
+           /InputMask: placeholderChar should be a single character/,
+           'placholderChar length > 1 is invalid')
+  t.throws(function() { new InputMask({pattern: '--11', placeholderChar: ''}) },
+           /InputMask: placeholderChar should be a single character/,
+           'placholderChar length < 1 is invalid')
+  t.end()
 })
 
 test('Skipping multiple static characters', function(t) {


### PR DESCRIPTION
Adds the option to customize the placeholder char to anything.  Using ' ' (space) removes the visual placeholder.