### PR TITLE
Add abilty to get raw collapsed value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -471,6 +471,16 @@ InputMask.prototype.getValue = function getValue() {
   return this.value.join('')
 }
 
+InputMask.prototype.getRawValue = function getRawValue() {
+  var rawValue = [];
+  for (var i=0; i < this.value.length; i++) {
+    if (this.pattern._editableIndices[i] === true) {
+      rawValue.push(this.value[i]);
+    }
+  }
+  return rawValue.join('');
+}
+
 InputMask.prototype._resetHistory = function _resetHistory() {
   this._history = []
   this._historyIndex = null

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,7 @@ test('formatValueToPattern', function(t) {
 })
 
 test('Constructor options', function(t) {
-  t.plan(12)
+  t.plan(15)
 
   t.throws(function() { new InputMask },
            /InputMask: you must provide a pattern./,
@@ -69,6 +69,13 @@ test('Constructor options', function(t) {
   mask.setPattern('--11--', {value: '99'})
   t.equal(mask.getValue(), '--99--', 'New pattern value is set')
   t.equal(mask.emptyValue, '--__--', 'emptyValue is updated after setPattern')
+
+  mask = new InputMask({pattern: '1111 1111', value: '98781'})
+  t.equal(mask.getValue(), '9878 1___', 'Intial value is correct')
+  mask.setPattern('111 111', {value: mask.getRawValue()})
+  t.equal(mask.getValue(), '987 81_', 'Mask is updated with no spaces')
+  mask.setPattern('11 11', {value: mask.getRawValue()})
+  t.equal(mask.getValue(), '98 78', 'Value is truncated to fit')
 
   // Custom format characters can be configured per-mask
   mask = new InputMask({


### PR DESCRIPTION
The use-case for this is to facilitate pattern changes.

`getRawValue` extracts the value without any non-pattern chars.