### PR TITLE
added new method hasValueChanged to check to see if a new value would…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -480,6 +480,13 @@ InputMask.prototype.getValue = function getValue() {
   return this.value.join('')
 }
 
+InputMask.prototype.hasValueChanged = function hasValueChanged(nextValue) {
+  if (!nextValue) {
+    nextValue = ''
+  }
+  return this.value.join('') !== this.pattern.formatValue(nextValue.split('')).join('')
+}
+
 InputMask.prototype.getRawValue = function getRawValue() {
   var rawValue = []
   for (var i = 0; i < this.value.length; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -426,3 +426,16 @@ test('History', function(t) {
   t.deepEqual([mask.getValue(), mask.selection], ['abc123', {start: 6, end: 6}])
   t.false(mask.redo(), 'invalid redo - nothing more to redo')
 })
+
+test('hasValueChanged', function(t) {
+  t.plan(2)
+
+  function checkValueChanged(value, pattern, nextValue) {
+    var mask = new InputMask({pattern: pattern})
+    mask.paste(value)
+    return mask.hasValueChanged(nextValue)
+  }
+
+  t.true(checkValueChanged('100', '111%', '99'), 'value should have changed')
+  t.false(checkValueChanged('100', '111%', '100'), 'value should not have changed')
+})


### PR DESCRIPTION
… change the output value of the mask

This is a new method that will be used by react-maskedinput to determine if new props will change the mask value.

It is to fix an issue in react-maskedinput where the onChange handler passed to the input rejects a change. In our case preventing people from entering a percentage value > 100%

mask: '111%'

Type: 9
MaskValue: 9%

Type: 9
MaskValue: 99%

Type: 9
MaskValue: 999%

But the value of 999 is rejected by onChange handler so component re-renders with props of 99 again. But the mask does not re-render as componentWillReceiveNewProps checks to see if props have changed and in this case have not.

A related fix in react-maskedinput will use this new method rather than just checking props to determine if it should update the mask value.