### PR TITLE
Allow empty string placeholderChars

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -194,8 +194,8 @@ function InputMask(options) {
     throw new Error('InputMask: you must provide a pattern.')
   }
 
-  if (options.placeholderChar.length !== 1) {
-    throw new Error('InputMask: placeholderChar should be a single character.')
+  if (typeof options.placeholderChar !== 'string' || options.placeholderChar.length > 1) {
+    throw new Error('InputMask: placeholderChar should be a single character or an empty string.')
   }
 
   this.placeholderChar = options.placeholderChar

--- a/test/index.js
+++ b/test/index.js
@@ -213,7 +213,7 @@ test('Leading static characters', function(t) {
 })
 
 test('Providing a custom placeholder character', function(t) {
-  t.plan(4)
+  t.plan(5)
 
   var mask = new InputMask({pattern: '---- 1111', placeholderChar: ' '})
   mask.selection = {start: 0, end: 15}
@@ -221,11 +221,15 @@ test('Providing a custom placeholder character', function(t) {
   t.equal(mask.getValue(), '---- 3   ',
           'Value applied to the first editable char with custom placeholderChar')
   t.throws(function() { new InputMask({pattern: '--11', placeholderChar: '__'}) },
-           /InputMask: placeholderChar should be a single character/,
+           /InputMask: placeholderChar should be a single character or an empty string./,
            'placholderChar length > 1 is invalid')
-  t.throws(function() { new InputMask({pattern: '--11', placeholderChar: ''}) },
-           /InputMask: placeholderChar should be a single character/,
-           'placholderChar length < 1 is invalid')
+
+  // With an empty string as the placeholderChar
+  mask = new InputMask({pattern: '---- 1111', placeholderChar: ''})
+  mask.selection = {start: 0, end: 15}
+  t.true(mask.input('3'), 'Valid input accepted with empty string placeholderChar')
+  t.equal(mask.getValue(), '---- 3',
+          'Value applied to the first editable char with empty string placeholderChar')
   t.end()
 })
 


### PR DESCRIPTION
This is to fix the case where a consumer does not want placeholders. For example, given a pattern `'--1111--'`, a placeholderChar of `''`, and a value of `'4'`, the input should show `'--4--'` instead of `'--4___--'`.