### PR TITLE
Fix bug when pasting value with multiple static parts in the middle

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -379,13 +379,9 @@ InputMask.prototype.paste = function paste(input) {
     // already have been stepped over by input(), so verify that the value
     // deemed invalid by input() was the expected static character.
     if (!valid) {
-      if (this.selection.start > 0) {
-        // XXX This only allows for one static character to be skipped
-        var patternIndex = this.selection.start - 1
-        if (!this.pattern.isEditableIndex(patternIndex) &&
-            input.charAt(i) === this.pattern.pattern[patternIndex]) {
-          continue
-        }
+      if (!this.pattern.isEditableIndex(i + this.pattern.firstEditableIndex) &&
+          input.charAt(i) === this.pattern.pattern[i + this.pattern.firstEditableIndex]) {
+        continue
       }
       extend(this, initialState)
       return false

--- a/test/index.js
+++ b/test/index.js
@@ -307,7 +307,7 @@ test('Backspace with selected range', function(t) {
 })
 
 test('Pasting', function(t) {
-  t.plan(10)
+  t.plan(11)
 
   var mask = new InputMask({
     pattern: '1111 1111 1111 1111'
@@ -335,6 +335,11 @@ test('Pasting', function(t) {
   // Pasted input can contain static formatting characters
   t.true(mask.paste('1234 1234 1234 1234'), 'Pasted value can contain static parts')
   t.equal(mask.getValue(), '1234 1234 1234 1234', 'Value after paste')
+
+  mask = new InputMask({
+    pattern: '1111 / 1111 / 1111 / 1111'
+  })
+  t.true(mask.paste('1234 / 1234 / 1234 / 1234'), 'Pasted value can contain several static parts')
 })
 
 test('Pasting with leading static pattern in selection', function(t) {


### PR DESCRIPTION
Hi! First of all thanks for the module!
I found a bug in handling pattern with multiple static parts in the middle of the mask in pate method, in this pr I added a test for this case and fix.